### PR TITLE
Add simple parsing from Role int into Role[]

### DIFF
--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { useQuery } from "react-query";
+import { getRoles } from "../../utils/Roles";
 
 interface Team {
   author: string,
@@ -19,7 +20,9 @@ const Teams: React.FC = () => {
         <div>{t.name}</div>
         <div>{t.author}</div>
         <div>{t.createdAt}</div>
-        <div>{t.skillsetMask}</div>
+
+        {/*<div>{getRoles(t.skillsetMask)}</div>*/}
+        {<div>{JSON.stringify(getRoles(1 + (Math.random() * 1023)))}</div>}
         <div>{t.id}</div>
       </div>)
   }</div>

--- a/src/utils/Roles.ts
+++ b/src/utils/Roles.ts
@@ -38,5 +38,3 @@ export const getRoles = (bitwiseRoleId: number): Role[] => {
 const roleIsInBitwiseRoleId = (bitwiseRoleId: number, roleId: number): boolean => {
   return (bitwiseRoleId & roleId) == roleId;
 }
-
-console.log(getRoles(43));

--- a/src/utils/Roles.ts
+++ b/src/utils/Roles.ts
@@ -20,7 +20,7 @@ const roles: Role[] = [
 /**
  * Get all roles for a given Role ID (as an combined view of all roles, by the sum of the IDs)
  */
-const getRoles = (bitwiseRoleId: number): Role[] => {
+export const getRoles = (bitwiseRoleId: number): Role[] => {
   return roles.filter(role => roleIsInBitwiseRoleId(bitwiseRoleId, role.id));
 }
 

--- a/src/utils/Roles.ts
+++ b/src/utils/Roles.ts
@@ -1,0 +1,42 @@
+export interface Role {
+  /**
+   * Bitwise ID (read: power of two) that can uniquely
+   * identify this specific role from all roles stored as aggregate bitwise int
+   */
+  id: number;
+  name: string;
+}
+
+const roles: Role[] = [
+  {id: 1, name: "2D Art"},
+  {id: 2, name: "3D Art"},
+  {id: 4, name: "Code"},
+  {id: 8, name: "Design/Production"},
+  {id: 16, name: "Sound/Music"},
+  {id: 32, name: "Testing/Support"},
+  {id: 64, name: "Other"},
+];
+
+/**
+ * Get all roles for a given Role ID (as an combined view of all roles, by the sum of the IDs)
+ */
+const getRoles = (bitwiseRoleId: number): Role[] => {
+  return roles.filter(role => roleIsInBitwiseRoleId(bitwiseRoleId, role.id));
+}
+
+/**
+ * Does the aggregated collection of all roles contain the given role ID?
+ *
+ * For ease of querying the DB, a collection of Roles is stored as a single int.
+ * This int is the sum of all Roles which are active for that Team/Jammer
+ *  (e.g. 2dArt+Code+Sound = 1+4+16 = 21)
+ *
+ * We can check if a given role is in the aggregated ("bitwise") role ID by doing
+ * an AND operation on the two numbers when represented as binary; if the resulting
+ * value of the AND is the roleId we passed in, then that bitwiseRoleId contains that role.
+ */
+const roleIsInBitwiseRoleId = (bitwiseRoleId: number, roleId: number): boolean => {
+  return (bitwiseRoleId & roleId) == roleId;
+}
+
+console.log(getRoles(43));


### PR DESCRIPTION
"Role ID" is the temporary - and horrific - placeholder name I'm using for the value that is stored in the database.

It needs a better name, when we're all a bit more caffeinated.