### PR TITLE
Refactoring Teams into Data class + other stuff

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+	"editor.detectIndentation": false,
+	"editor.tabSize": 2,
+	"editor.insertSpaces": true
+}

--- a/src/components/Team.tsx
+++ b/src/components/Team.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { getRoles, Role } from "../utils/Roles";
+
+export class TeamData {
+  author: string;
+  description: string;
+  skills: Array<Role>;
+  createdAt: Date;
+  id: number;
+  constructor(teamJSON: Record<string, unknown>){
+    this.author = teamJSON.author as string;
+    // using lorem as the description, awaiting DB change:
+    // this.description = teamJSON.description as string;
+    this.description = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim"
+    this.createdAt = new Date(teamJSON.createdAt as string);
+    // currently using a random role instead of the one from the DB, to introduce some variation
+    // this.skills = getRoles(teamJSON.skillsetMask as number);
+    this.skills = getRoles(1 + (Math.random() * 1023));
+    this.id = teamJSON.id as number;
+  }
+}
+
+export const Team: React.FC<{team:TeamData}> = ({team}) => {
+  // 3600000ms in an hour
+  var h = (Date.now() - team.createdAt.valueOf()) / 3600000;
+  var timestr = h.toFixed(1) + " Hours ago"
+
+  var skillstr = team.skills.map(r => r.name).toString().replaceAll(',', ', ');
+
+  return (
+    <div className="py-3">
+      <div>{team.author}</div>
+      <div>{team.description}</div>
+      <div>{timestr}</div>
+      <div>{skillstr}</div>
+    </div>
+  )
+}

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -1,50 +1,30 @@
-import React, { useState } from "react";
+import React from "react";
 import { useQuery } from "react-query";
-import { getRoles } from "../../utils/Roles";
-
-interface Team {
-  author: string,
-  createdAt: string,
-  name: string,
-  skillsetMask: number,
-  id: number
-}
-
-const Teams: React.FC = () => {
-  const { isLoading, isError, data } = useQuery(["someQuery"], async (): Promise<Array<Team>> => {
-    return fetch("http://178.62.53.195/teams", {mode:"cors"}).then(res => res.json());
-  });
-
-  return <div>{
-    isLoading ? "Loading.." : isError ? "fuck" : data!.map(t => <div key={t.id} className="p-3">
-        <div>{t.name}</div>
-        <div>{t.author}</div>
-        <div>{t.createdAt}</div>
-
-        {/*<div>{getRoles(t.skillsetMask)}</div>*/}
-        {<div>{JSON.stringify(getRoles(1 + (Math.random() * 1023)))}</div>}
-        <div>{t.id}</div>
-      </div>)
-  }</div>
-}
+import { TeamData, Team } from "../../components/Team"
 
 export const Home: React.FC = () => {
-  const [count, setCount] = useState(0);
+	
+  const { isLoading, isError, data, refetch } = useQuery(["Teams"], async (): Promise<Array<TeamData>> => {
+    var arr: Array<Record<string, unknown>> = await fetch("http://178.62.53.195/teams", {mode:"cors"}).then(res => res.json());
+    return arr.map(t => new TeamData(t));
+  });
 
   return (
-    <div className="container mx-auto my-6">
-      <h1 className="text-3xl text-primary font-light px-6 pb-6">
-        Hello World
+    <div className="container mx-auto my-6 p-2">
+      <h1 className="text-3xl text-primary font-light my-6">
+        Find a team!
       </h1>
-      <div className="border border-white p-6 space-y-3 border-opacity-25">
-        <button
-          className="bg-primary-dark p-2 focus:outline-none focus-visible:outline-none focus-visible:ring focus-visible:ring-primary"
-          onClick={() => setCount((count) => count + 1)}
-        >
-          count is: {count}
-        </button>
-        <Teams/>
-      </div>
+
+      <button
+        className="bg-primary-dark my-6 p-2 focus:outline-none focus-visible:outline-none focus-visible:ring focus-visible:ring-primary"
+        onClick={() => refetch()}
+      >
+        Refetch Teams
+      </button>
+
+      <div>{
+        isLoading ? "Loading.." : isError ? "fuck" : data!.map(t => <Team key={t.id} team={t}/>)
+      }</div>
     </div>
   );
 };


### PR DESCRIPTION
Put all the team-related stuff into src/components/Team, and created a data class for processing the JSON into something richer and more useful

The TeamData class ignores the name field, and uses Lorem Ipsum as placeholder for the description field, awaiting DB/API change

the Team component displays info in a way that's somewhat more useful and a lot less horrible

The homepage is now less placeholder - the button now refetches team data instead of incrementing a counter, and the JSX is a bit shallower

oh, and there's VScode settings so that anybody loading it up in VScode has the correct indentation set.