### PR TITLE
Authentication interaction with backend

### DIFF
--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -2,6 +2,9 @@ import * as React from "react";
 import { Switch, Route } from "react-router-dom";
 import { Home } from "./pages/Home/Home";
 import { Register } from "./pages/Register/Register";
+import { Login } from "./pages/Login/Login"
+import { AuthorizedCallback } from "./pages/Login/AuthorizedCallback";
+import { AuthReq } from "./pages/Login/AuthReq";
 
 export const Routes: React.FC = () => (
   <Switch>
@@ -10,6 +13,17 @@ export const Routes: React.FC = () => (
     </Route>
     <Route exact={true} path="/register">
       <Register />
+    </Route>
+    <Route exact={true} path="/login">
+      <Login />
+    </Route>
+    <Route exact={true} path="/login/failed">
+    </Route>
+    <Route exact={true} path="/login/authorized">
+      <AuthorizedCallback />
+    </Route>
+    <Route exact={true} path="/req">
+      <AuthReq />
     </Route>
   </Switch>
 );

--- a/src/pages/Login/AuthReq.tsx
+++ b/src/pages/Login/AuthReq.tsx
@@ -1,0 +1,26 @@
+import * as React from "react";
+import { PageContainer } from "../../components/PageContainer";
+import { PageHeader } from "../../components/PageHeader";
+
+export const AuthReq: React.FC = () => {
+    const token = localStorage.getItem("token")
+
+    fetch("http://localhost:8080/teams/1", {
+        headers: {
+            "Authorization": "Bearer " + token,
+            "Access-Control-Allow-Origin": "*",
+            'Content-Type': 'application/json',
+            'Accept': 'application/json'
+        }
+    })
+    .then(r => r.json())
+    .then(r => console.log(r))
+    .catch(e => console.log("ERROR: ", e))
+
+    return (
+        <PageContainer>
+            <PageHeader>Authorization Successful</PageHeader>
+            <div>We made it!</div>
+        </PageContainer>
+    )
+}

--- a/src/pages/Login/AuthorizedCallback.tsx
+++ b/src/pages/Login/AuthorizedCallback.tsx
@@ -1,0 +1,25 @@
+import * as React from "react";
+import { PageContainer } from "../../components/PageContainer";
+import { PageHeader } from "../../components/PageHeader";
+import { useLocation } from "react-router-dom"
+
+export const AuthorizedCallback: React.FC = () => {
+    const query = new URLSearchParams(useLocation().search)
+    const token = query.get("token")
+    if (token == null) {
+        return (
+            <PageContainer>
+                <PageHeader>Error</PageHeader>
+                <div>Should show error page</div>
+            </PageContainer>
+        )
+    }
+
+    localStorage.setItem("token", token)
+    return (
+        <PageContainer>
+            <PageHeader>Authorization Successful</PageHeader>
+            <div>We made it!</div>
+        </PageContainer>
+    )
+}

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -1,0 +1,14 @@
+import * as React from "react";
+import { PageContainer } from "../../components/PageContainer";
+import { PageHeader } from "../../components/PageHeader";
+
+export const Login: React.FC = () => {
+    const url = `${import.meta.env.VITE_API_URL}/oauth2/authorization/discord`
+
+    return (
+        <PageContainer>
+            <PageHeader>Login</PageHeader>
+            <a href={url}>Login with Discord</a>
+        </PageContainer>
+    )
+}


### PR DESCRIPTION
This is mainly example code on how the interaction with the backend for authentication would happen

On `/login` these is a sign in with discord button, this starts the auth flow
If this flow is done and
Succeeds: the backend will redirect to `/login/authorized` with the created jwt token in the query string
Failes: the backend will redirect to `/login/failed` with the reason of failure in the query string

The AuthReq and /req route is testing a fetch to a authenticated endpoint using the token

There are still things missing like refreshing the token while the user is still logged in but that isn't ready on the backend yet