### PR TITLE
Pagination and Sort

### DIFF
--- a/public/spinner.svg
+++ b/public/spinner.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid">
+<circle cx="50" cy="50" fill="none" stroke="#00ffc0" stroke-width="7" r="41" stroke-dasharray="193.20794819577225 66.40264939859075">
+  <animateTransform attributeName="transform" type="rotate" repeatCount="indefinite" dur="1.1363636363636365s" values="0 50 50;360 50 50" keyTimes="0;1"></animateTransform>
+</circle>
+</svg>

--- a/src/components/Team.tsx
+++ b/src/components/Team.tsx
@@ -16,18 +16,18 @@ export class TeamData {
   authorId: string;
   description: string;
   skills: Array<Skillset>;
-  createdAt: Date;
+  updatedAt: Date;
   id: number;
   constructor(teamJSON: Record<string, unknown>){
     this.author = teamJSON.author as string;
     this.authorId = teamJSON.authorId as string;
     this.description = teamJSON.description as string;
 
-    const createdAt = teamJSON.createdAt as string;
-    this.createdAt = new Date(createdAt);
+    const updatedAt = teamJSON.updatedAt as string;
+    this.updatedAt = new Date(updatedAt);
     // Safari can't handle YYYY-mm-dd HH:MM:ss, but it _can_ handle YYYY-mm-ddTHH:MM:ss
-    if (isNaN(this.createdAt.getTime())) {
-      this.createdAt = new Date(createdAt.replace(" ", "T"))
+    if (isNaN(this.updatedAt.getTime())) {
+      this.updatedAt = new Date(updatedAt.replace(" ", "T"))
     }
 
     this.skills = getSkillsets(teamJSON.skillsetMask as number);
@@ -37,11 +37,11 @@ export class TeamData {
 
 export const Team: React.FC<{team:TeamData}> = ({team}) => {
 
-  const skillstr = team.skills.map(r => <SkillsetSVG skillsetId={r.id} key={r.id} className="w-7 fill-primary inline-block m-1 align-top"/>);
+  const skills = team.skills.map(r => <SkillsetSVG skillsetId={r.id} key={r.id} className="w-10 fill-primary inline-block m-1 align-top"/>);
 
   return (
-    <div data-team-id={team.id} className="my-8 p-5 border relative">
-      <div className="absolute -top-2.5 left-1 px-3 bg-black leading-none font-bold text-lg">
+    <div data-team-id={team.id} className="my-12 p-5 border relative">
+      <div className="absolute -top-3.5 left-1 px-3 bg-black leading-none font-bold text-lg">
         <a href={`https://discordapp.com/users/${team.authorId}`} target="_blank" rel="noreferrer">
           <span className="pb-1 border-b-2 border-white" style={{borderBottomWidth: "1px"}}>
             🔗 {team.author}&rsquo;s Team
@@ -49,10 +49,13 @@ export const Team: React.FC<{team:TeamData}> = ({team}) => {
         </a>
       </div>
       <div className="flex justify-between">
-        <div className="mr-5 text-lg">{team.description}</div>
+        <div className="mr-5 mt-1 text-lg pb-7">
+          {team.description}
+          <div className="text-sm absolute bottom-3 left-4">🕗 {timeAgo.format(team.updatedAt)}</div>
+        </div>
         <div>
-          <div className="mb-1">🕓 {timeAgo.format(team.createdAt)}</div>
-          <div className="text-lg w-36">🔎 {skillstr}</div>
+          <div className="mb-1">Looking for skills:</div>
+          <div className="text-lg w-48">{skills}</div>
         </div>
       </div>
     </div>

--- a/src/components/Team.tsx
+++ b/src/components/Team.tsx
@@ -49,7 +49,7 @@ export const Team: React.FC<{team:TeamData}> = ({team}) => {
         </a>
       </div>
       <div className="flex justify-between">
-        <div className="mr-5 mt-1 text-lg pb-7">
+        <div className="mr-5 mt-1 text-lg pb-7 overflow-hidden">
           {team.description}
           <div className="text-sm absolute bottom-3 left-4">🕗 {timeAgo.format(team.updatedAt)}</div>
         </div>

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -1,44 +1,10 @@
 import React, { useState } from "react";
-import { useQuery } from "react-query";
+import { useInfiniteQuery } from "react-query";
 import { PageHeader } from "../../components/PageHeader";
 import { TeamData, Team } from "../../components/Team";
 import { SkillsetSelector } from "../../components/SkillsetSelector";
-import { getAllTeams } from "../../utils/TeamActions";
-
-interface TLprops { selectedSkillsets: number[] }
-const TeamList: React.FC<TLprops> = ({selectedSkillsets}) => {
-  const skillsetMask = selectedSkillsets.length
-    ? selectedSkillsets.reduce((a, b) => a + b, 0)
-    : null;
-
-  const { isLoading, isError, data, refetch } = useQuery(["Teams", skillsetMask],
-    async (): Promise<Array<TeamData>> => {
-      return ( await getAllTeams({skillsetMask}) ).map((t) => new TeamData(t));
-    },
-    {
-      keepPreviousData: true,
-    }
-  );
-
-  return (
-    <div>
-      <button
-        onClick={() => refetch()}
-        className="block bg-primary-dark my-6 p-2 focus:outline-none"
-      >
-        Find A Team!
-      </button>
-
-      <div>
-        {!data && isLoading
-          ? "Loading.."
-          : isError
-          ? "Sorry, something went wrong. Please try again in a few minutes."
-          : data!.map((t) => <Team key={t.id} team={t} />)}
-      </div>
-    </div>
-  );
-};
+import { getTeamsList } from "../../utils/TeamActions";
+import { getLastItem } from "../../utils/getLastItem";
 
 export const Home: React.FC = () => {
   const [selectedSkillsets, setSelectedSkillsets] = useState<number[]>([]);
@@ -51,6 +17,67 @@ export const Home: React.FC = () => {
       selectedSkillsets={selectedSkillsets}
       onChange={setSelectedSkillsets}
     />
-    <TeamList selectedSkillsets={selectedSkillsets} />
+    <TeamList skillsetMask={ selectedSkillsets.reduce((a, b) => a + b, 0) } />
   </>);
+};
+
+type orderVals = "desc" | "asc" | "random";
+
+const TeamList: React.FC<{skillsetMask:number}> = ({skillsetMask}) => {
+  const [order, updateOrder] = useState<orderVals>("desc");
+
+  const { isLoading, isError, data, refetch, fetchNextPage } = useInfiniteQuery(["Teams", skillsetMask, order],
+    async ({pageParam = 1}): Promise<Array<TeamData>> => {
+      const query = {
+        skillsetMask, order,
+        page: pageParam
+      };
+      return ( await getTeamsList(query) ).map((t) => new TeamData(t));
+    },
+    {
+      keepPreviousData: true
+    }
+  );
+  const pagesArray = data ? data.pages : [] as TeamData[][];
+
+  const fetchNext = () => {
+    if(getLastItem(pagesArray).length < 25) return;
+    
+    const pp = getLastItem(data!.pageParams as (number | undefined)[]) || 1;
+    fetchNextPage({pageParam: pp + 1});
+  }
+
+  return (
+    <div>
+      <select className="text-black" value={order} onChange={e => updateOrder(e.target.value as orderVals)}>
+        <option value="desc">Newest First</option>
+        <option value="asc">Oldest First</option>
+        <option value="random">Random</option>
+      </select>
+      <button
+        onClick={fetchNext}
+        className="block bg-primary-dark my-6 p-2 focus:outline-none"
+        disabled={isLoading}
+      >
+        Load Next
+      </button>
+      <button
+        onClick={() => refetch()}
+        className="block bg-primary-dark my-6 p-2 focus:outline-none"
+        disabled={isLoading}
+      >
+        {isLoading ? "Loading..." : "Refresh List"}
+      </button>
+
+      <div>
+        {isError ?
+          "Sorry, something went wrong. Please try again in a few minutes." :
+          pagesArray.map(arr =>
+            arr.map((t) => <Team key={t.id} team={t} />)
+          )
+         }
+        {isLoading ? <img src="https://c.tenor.com/I6kN-6X7nhAAAAAj/loading-buffering.gif" /> : null}
+      </div>
+    </div>
+  );
 };

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -1,10 +1,24 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useInfiniteQuery } from "react-query";
 import { PageHeader } from "../../components/PageHeader";
 import { TeamData, Team } from "../../components/Team";
 import { SkillsetSelector } from "../../components/SkillsetSelector";
-import { getTeamsList } from "../../utils/TeamActions";
-import { getLastItem } from "../../utils/getLastItem";
+
+const getTeamsList = (
+  queryParams: {
+    order: "asc" | "desc" | "random";
+    skillsetMask: number;
+    page: number;
+  }
+): Promise<Array<Record<string, unknown>>> => {
+  const url = new URL(`${import.meta.env.VITE_API_URL}/teams`);
+
+  for(const [k, v] of Object.entries(queryParams)) url.searchParams.append(k, v.toString());
+
+  return fetch(url.toString(), { mode: "cors" }).then((res) => res.json());
+};
+
+const pageSize = 25;
 
 export const Home: React.FC = () => {
   const [selectedSkillsets, setSelectedSkillsets] = useState<number[]>([]);
@@ -26,38 +40,48 @@ type orderVals = "desc" | "asc" | "random";
 const TeamList: React.FC<{skillsetMask:number}> = ({skillsetMask}) => {
   const [order, updateOrder] = useState<orderVals>("desc");
 
-  const { isLoading, isError, data, refetch, fetchNextPage } = useInfiniteQuery(["Teams", skillsetMask, order],
-    async ({pageParam: page = 1}): Promise<Array<TeamData>> => {
-      return ( await getTeamsList( { skillsetMask, order, page } ) ).map((t) => new TeamData(t));
-    },
+  const {
+    isFetchingNextPage, isLoading: initalLoad, isError, data, fetchNextPage
+  } = useInfiniteQuery(["Teams", skillsetMask, order],
+    async ({pageParam: page = 1}) =>
+      ( await getTeamsList({ skillsetMask, order, page }) ).map((t) => new TeamData(t)),
     {
-      keepPreviousData: true,
-      getNextPageParam: (lastPage, allPages) => lastPage.length < 25 ? undefined : allPages.length
+      getNextPageParam: (lastPage, allPages) => lastPage.length < pageSize ? undefined : allPages.length
     }
   );
   const pagesArray = data ? data.pages : [] as TeamData[][];
+  const isLoading = initalLoad || isFetchingNextPage;
+
+  const lastPage = pagesArray[pagesArray.length - 1] || [];
+  const allLoaded = lastPage.length < pageSize;
+
+  useEffect(() => {
+    if(allLoaded) return;
+    const de = document.documentElement;
+
+    const onScroll = () => {
+      const distanceLeft = de.scrollHeight - (de.scrollTop + innerHeight);
+      if(distanceLeft < 200) fetchNextPage();
+    }
+
+    window.addEventListener("scroll", onScroll, {passive: true});
+    de.addEventListener("scroll", onScroll, {passive: true});
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      de.removeEventListener("scroll", onScroll);
+    }
+  }, [fetchNextPage, allLoaded]);
 
   return (
     <div>
-      <select className="text-black" value={order} onChange={e => updateOrder(e.target.value as orderVals)}>
-        <option value="desc">Newest First</option>
-        <option value="asc">Oldest First</option>
-        <option value="random">Random</option>
-      </select>
-      <button
-        onClick={() => fetchNextPage()}
-        className="block bg-primary-dark my-6 p-2 focus:outline-none"
-        disabled={isLoading}
-      >
-        Load Next
-      </button>
-      <button
-        onClick={() => refetch()}
-        className="block bg-primary-dark my-6 p-2 focus:outline-none"
-        disabled={isLoading}
-      >
-        {isLoading ? "Loading..." : "Refresh List"}
-      </button>
+      <label className="text-lg">
+        Sort By:
+        <select className="text-black block p-1 pb-1.5 mt-1 outline-none" value={order} onChange={e => updateOrder(e.target.value as orderVals)}>
+          <option value="desc">Newest First</option>
+          <option value="asc">Oldest First</option>
+          <option value="random">Random</option>
+        </select>
+      </label>
 
       <div>
         {isError ?
@@ -65,9 +89,14 @@ const TeamList: React.FC<{skillsetMask:number}> = ({skillsetMask}) => {
           pagesArray.map(arr =>
             arr.map((t) => <Team key={t.id} team={t} />)
           )
-         }
+        }
+        {/* literally just slapped in. please replace it. god. please. */}
         {isLoading ? <img src="https://c.tenor.com/I6kN-6X7nhAAAAAj/loading-buffering.gif" /> : null}
       </div>
+
+      {allLoaded ?
+        <div className="text-center text-2xl pb-10">No more teams to load</div>
+      : null}
     </div>
   );
 };

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -27,25 +27,15 @@ const TeamList: React.FC<{skillsetMask:number}> = ({skillsetMask}) => {
   const [order, updateOrder] = useState<orderVals>("desc");
 
   const { isLoading, isError, data, refetch, fetchNextPage } = useInfiniteQuery(["Teams", skillsetMask, order],
-    async ({pageParam = 1}): Promise<Array<TeamData>> => {
-      const query = {
-        skillsetMask, order,
-        page: pageParam
-      };
-      return ( await getTeamsList(query) ).map((t) => new TeamData(t));
+    async ({pageParam: page = 1}): Promise<Array<TeamData>> => {
+      return ( await getTeamsList( { skillsetMask, order, page } ) ).map((t) => new TeamData(t));
     },
     {
-      keepPreviousData: true
+      keepPreviousData: true,
+      getNextPageParam: (lastPage, allPages) => lastPage.length < 25 ? undefined : allPages.length
     }
   );
   const pagesArray = data ? data.pages : [] as TeamData[][];
-
-  const fetchNext = () => {
-    if(getLastItem(pagesArray).length < 25) return;
-    
-    const pp = getLastItem(data!.pageParams as (number | undefined)[]) || 1;
-    fetchNextPage({pageParam: pp + 1});
-  }
 
   return (
     <div>
@@ -55,7 +45,7 @@ const TeamList: React.FC<{skillsetMask:number}> = ({skillsetMask}) => {
         <option value="random">Random</option>
       </select>
       <button
-        onClick={fetchNext}
+        onClick={() => fetchNextPage()}
         className="block bg-primary-dark my-6 p-2 focus:outline-none"
         disabled={isLoading}
       >

--- a/src/pages/Register/Register.tsx
+++ b/src/pages/Register/Register.tsx
@@ -12,7 +12,7 @@ import {
   TeamDto,
 } from "../../utils/TeamActions";
 import { getSkillsets } from "../../utils/Skillsets";
-import match from "../../utils/match";
+import { match } from "../../utils/match";
 
 export interface FormData {
   description: string;

--- a/src/utils/TeamActions.ts
+++ b/src/utils/TeamActions.ts
@@ -5,20 +5,6 @@ export interface TeamDto {
   skillsetMask: number;
 }
 
-export const getTeamsList = (
-  queryParams: {
-    order: "asc" | "desc" | "random";
-    skillsetMask: number;
-    page: number;
-  }
-): Promise<Array<Record<string, unknown>>> => {
-  const url = new URL(`${import.meta.env.VITE_API_URL}/teams`);
-
-  for(const [k, v] of Object.entries(queryParams)) url.searchParams.append(k, v.toString());
-
-  return fetch(url.toString(), { mode: "cors" }).then((res) => res.json());
-};
-
 export const createTeam = async (formData: FormData): Promise<TeamDto> => {
   const team = teamFromForm(formData);
   await makeApiRequest("/teams", "POST", team);

--- a/src/utils/TeamActions.ts
+++ b/src/utils/TeamActions.ts
@@ -5,18 +5,16 @@ export interface TeamDto {
   skillsetMask: number;
 }
 
-type QueryParam = string | number | null;
-
-export const getAllTeams = (
-  queryParams: Record<string, QueryParam>
+export const getTeamsList = (
+  queryParams: {
+    order: "asc" | "desc" | "random";
+    skillsetMask: number;
+    page: number;
+  }
 ): Promise<Array<Record<string, unknown>>> => {
   const url = new URL(`${import.meta.env.VITE_API_URL}/teams`);
 
-  Object.entries(queryParams).forEach(([k, v]) => {
-    if (v != null && v != undefined) {
-      url.searchParams.append(k, v.toString());
-    }
-  });
+  for(const [k, v] of Object.entries(queryParams)) url.searchParams.append(k, v.toString());
 
   return fetch(url.toString(), { mode: "cors" }).then((res) => res.json());
 };

--- a/src/utils/getLastItem.ts
+++ b/src/utils/getLastItem.ts
@@ -1,3 +1,0 @@
-export function getLastItem<T>(arr: T[]): T{
-  return arr[arr.length - 1];
-}

--- a/src/utils/getLastItem.ts
+++ b/src/utils/getLastItem.ts
@@ -1,0 +1,3 @@
+export function getLastItem<T>(arr: T[]): T{
+  return arr[arr.length - 1];
+}

--- a/src/utils/match.ts
+++ b/src/utils/match.ts
@@ -1,3 +1,89 @@
+/*
+These functions are made to work similarly to the Rust match expression, or the Kotlin when expression.
+
+Example uses:
+
+let status: "loading" | "loaded" | "error"
+let data: {} | null
+
+// match<T, RT>(val:T, ...matches: [T, RT][]): RT | undefined
+Takes a value, followed by a list of tuples.
+If the value matches the first item in one of the tuples, then the second item from that tuple is returned.
+
+status = "error";
+
+// returns "Uh oh..."
+match(status,
+  ["loading", "Loading..."],
+  ["error", "Uh oh..."],
+)
+
+
+
+// matchFunc<T, RT>(val:T, ...matches: [T, ()=>RT][]): RT | undefined
+Pretty much the same as `match`, except requires a function as the second item in the tuples.
+This is useful for when you don't want the expression to evaluate until it's returned.
+
+Consider this use case, with `match`
+
+status = "loading"
+data = null
+
+match(status,
+  ["loading", "Loading..."],
+  // Error! Cannot read property toString of null
+  ["loaded", data.toString()],
+)
+
+This use case is solved with `matchFunc`
+
+matchFunc(status,
+  ["loading", ()=> "Loading..."],
+  ["loaded", ()=> data.toString()],
+)
+
+
+
+// matchif<RT>(...matches: [unknown, RT][]): RT | undefined
+Pretty much the same as `match`, except it only matches the first tuple value based on truthyness
+ie. it's the same as if you plugged the value into an `if` statment.
+This means there's no need for the value to match against, either.
+
+status = "loaded"
+data = {}
+
+matchif(
+  // data is truthy, so it's returned
+  [data, data],
+  [status == "loading", "Loading..."]
+)
+
+
+
+// matchifFunc<RT>(...matches: [unknown, ()=>RT][]): RT | undefined
+Same thing to `matchif` that `matchFunc` is to `match`.
+Pretty much the same as `matchif`, except requires a function as the second item in the tuples.
+This is useful for when you don't want the expression to evaluate until it's returned.
+
+Consider this use case, with `matchif`
+
+status = "loading"
+data = null
+
+matchif(
+  [status == "loading", "Loading..."],
+  // Error! Cannot read property toString of null
+  [data, data.toString()],
+)
+
+This use case is solved with `matchifFunc`
+
+matchifFunc(
+  [status == "loading", ()=> "Loading..."],
+  ["loaded", ()=> data.toString()],
+)
+*/
+
 export function match<T, RT>(val:T, ...matches: [T, RT][]): RT | undefined {
   for(const [match, rtn] of matches) if(val == match) return rtn;
 }

--- a/src/utils/match.ts
+++ b/src/utils/match.ts
@@ -1,6 +1,12 @@
 export function match<T, RT>(val:T, ...matches: [T, RT][]): RT | undefined {
   for(const [match, rtn] of matches) if(val == match) return rtn;
 }
-export function matchf<T, RT>(val:T, ...matches: [T, ()=>RT][]): RT | undefined {
-  for(const [match, f] of matches) if(val == match) return f();
+export function matchFunc<T, RT>(val:T, ...matches: [T, ()=>RT][]): RT | undefined {
+  for(const [match, rtn] of matches) if(val == match) return rtn();
+}
+export function matchif<RT>(...matches: [unknown, RT][]): RT | undefined {
+  for(const [val, rtn] of matches) if(val) return rtn;
+}
+export function matchifFunc<RT>(...matches: [unknown, ()=>RT][]): RT | undefined {
+  for(const [val, rtn] of matches) if(val) return rtn();
 }

--- a/src/utils/match.ts
+++ b/src/utils/match.ts
@@ -1,3 +1,6 @@
-export default function match<T, RT>(val:T, ...matches: [T, RT][]): RT | undefined {
+export function match<T, RT>(val:T, ...matches: [T, RT][]): RT | undefined {
   for(const [match, rtn] of matches) if(val == match) return rtn;
+}
+export function matchf<T, RT>(val:T, ...matches: [T, ()=>RT][]): RT | undefined {
+  for(const [match, f] of matches) if(val == match) return f();
 }


### PR DESCRIPTION
There's now paginated infinite scrolling implemented on the Home page, with a drop-down to change sort order (Newest First is the default).

I removed the "Refresh Teams" button, as I didn't want to confuse users - they might think they need to press it to update the page after changing filter options, but it actually updates automatically.

For the same UX reason, I also removed the option that keeps showing team data while loading. Instead, if loading needs doing, the spinner appears, so the user knows their actions had an effect.

I've also added a nice loading spinner and some text that tells users when they've seen all the teams.

There's also a refactor of some of the most recent major additons to `main`, to make things more concise, and make use of `matchif` (see commit message for deets)