### PR TITLE
Creating the Status Messenger

### DIFF
--- a/src/components/StatusMessenger.tsx
+++ b/src/components/StatusMessenger.tsx
@@ -1,0 +1,52 @@
+import * as React from "react";
+
+type Message = {
+  styleClass: string;
+  text: string;
+};
+const messages: Message[] = [];
+
+// supposed to be a singleton
+let compInstance: StatusMessenger | null;
+
+export function AddMessage(styleClass: string, messageText: string, displayTime = 7500): void {
+  if(!compInstance) {
+    console.warn("StatusMessenger not initalised");
+    return;
+  }
+
+  const msg = {styleClass, text: messageText};
+
+  messages.push(msg);
+  if(messages.length > 5) messages.shift();
+  compInstance.forceUpdate();
+
+  setTimeout(() => {
+    const ind = messages.indexOf(msg);
+    if(ind == -1) return;
+
+    messages.splice(ind, 1);
+    compInstance!.forceUpdate();
+  }, displayTime);
+}
+
+
+const StatusMessage: React.FC<{message: Message}> = ({message: {styleClass, text}}) =>
+  (<div className={"p-3 my-8 rounded text-center text-lg font-bold "+styleClass}>
+    {text}
+  </div>);
+
+// no props
+type Props = Record<string, never>;
+export class StatusMessenger extends React.Component<Props> {
+  constructor(props: Props){
+    super(props);
+    compInstance = this;
+  }
+
+  render(): React.ReactNode {
+    return (<div className="fixed bottom-0 max-w-md w-full inset-x-0 mx-auto text-center px-8">
+      {messages.map((m, i) => <StatusMessage key={i} message={m} />)}
+    </div>);
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,6 +9,7 @@ import "./index.css";
 import { PageNavigator } from "./components/PageNavigator";
 import { NavLink } from "react-router-dom";
 import { PageContainer } from "./components/PageContainer";
+import { StatusMessenger } from "./components/StatusMessenger";
 
 ReactDOM.render(
   <React.StrictMode>
@@ -30,6 +31,7 @@ ReactDOM.render(
         <Routes />
       </PageContainer>
       <ReactQueryDevtools />
+      <StatusMessenger />
     </Context>
   </React.StrictMode>,
   document.getElementById("root")

--- a/src/pages/Register/Register.tsx
+++ b/src/pages/Register/Register.tsx
@@ -14,6 +14,7 @@ import {
 import { getSkillsets } from "../../utils/Skillsets";
 import { match, matchif } from "../../utils/match";
 import { PageUserInfo } from "../../components/PageUserInfo";
+import { AddMessage } from "../../components/StatusMessenger";
 
 export interface FormData {
   description: string;
@@ -114,11 +115,11 @@ export const Register: React.FC = () => {
   const charRemain = charLimit - description.length;
   const remainColor = charRemain <= 0 ? "text-red-400" : "";
 
-  // Configuring the look + message of the status bar
+  // Configuring the look + message of the status message
   const [statusClass, statusMsg] = matchif(
-    [isSaving, ["bg-transparent border", "Saving..."]],
+    [isSaving, ["bg-black border", "Saving..."]],
 
-    [isDeleting, ["bg-transparent border", "Deleting..."]],
+    [isDeleting, ["bg-black border", "Deleting..."]],
 
     [lastFormEvent == "error", [
       "bg-red-500",
@@ -138,17 +139,17 @@ export const Register: React.FC = () => {
       "bg-red-500",
       "An error occurred while checking if you already have a team, please refresh the page."
     ]],
-  ) || ["bg-transparent border", "Use the form below to let people know about your team!"];
+  ) || ["", ""];
+
+  React.useEffect(() => {
+    if(statusMsg != "") AddMessage(statusClass, statusMsg);
+  }, [statusClass, statusMsg]);
 
   return (
     <>
       <PageUserInfo />
-
-      <div className={"p-2 m-8 rounded text-center text-lg font-bold transition " + statusClass}>
-        {statusMsg}
-      </div>
       <form
-        className="mx-auto space-y-8"
+        className="mx-auto space-y-8 pb-12"
         onSubmit={handleSubmit((data) =>
           saveMutate({ userTeam, formData: data })
         )}


### PR DESCRIPTION
The Status Messenger provides APIs for a series of customisable, stylable messages at the bottom of the screen, as a replacement for the status bar on the Register page, but I also figure it'd be useful for other times we want to communicate app state to the user.

This thing completely breaks the way React is supposed to work by calling forceUpdate from outside a component, and having the data that component renders exist outside of it. I'm not sure how else you handle something like this, though.

I'd recommend people download and try the branch before reviewing - it's definitely rough around the edges in both code and UX, but I think it's an improvement on what we had, and will be useful going forward.