### PR TITLE
Ensure a Report is only submitted once per user/team

### DIFF
--- a/src/components/ReportButton.tsx
+++ b/src/components/ReportButton.tsx
@@ -12,7 +12,7 @@ const successfulSubmitText = "Your report has been received, a moderator will in
 
 const trySubmitReport = async (teamId: string) => {
   if (!isUserLoggedIn()) return AddMessage("bg-red-500", "Please login to report a team");
-  if (userReportedTeam(teamId)) AddMessage("bg-primary-dark", successfulSubmitText);
+  if (userReportedTeam(teamId)) return AddMessage("bg-primary-dark", successfulSubmitText);
   
 
   const res = await reportTeam(teamId);


### PR DESCRIPTION
The message will still pop up repeatedly, which I'm fine with