### PR TITLE
Make border size of PageNavigator tabs consistent

### DIFF
--- a/src/components/PageNavigator.tsx
+++ b/src/components/PageNavigator.tsx
@@ -6,7 +6,7 @@ const NavTab: React.FC<{to: string}> = ({children, ...props}) => (
     {...props}
     exact={true}
     activeClassName="text-primary font-medium"
-    activeStyle={{transform: "translate(0px, 1px)", borderWidth: "3px 3px 0 3px", background:"linear-gradient(#333, #000)"}}
+    activeStyle={{transform: "translate(0px, 2px)", borderWidth: "3px 3px 0 3px", background:"linear-gradient(#333, #000)"}}
     className="leading-tight text-2xl font-light bg-black py-3 px-4 w-48 text-white text-center uppercase whitespace-pre rounded-t-lg border-t border-l border-r"
   >
     {children}
@@ -14,7 +14,7 @@ const NavTab: React.FC<{to: string}> = ({children, ...props}) => (
 )
 
 export const PageNavigator: React.FC = () => (
-  <div className="flex flex-row justify-center items-center space-x-4 my-8 border-b border-white">
+  <div className="flex flex-row justify-center items-center space-x-4 my-8 border-b border-white" style={{borderBottomWidth: "2px"}}>
     <NavTab to="/">Team<br/>Finder</NavTab>
     <NavTab to="/register">Post / Edit<br/>Your Team</NavTab>
     <NavTab to="/about">FAQ /<br/>About</NavTab>


### PR DESCRIPTION
Not sure if valid, but makes the nav bottom border match the selected tab border size 

![image](https://user-images.githubusercontent.com/13312237/120024248-c9906980-bfe6-11eb-962b-057401745af3.png)