### PR TITLE
Reducing contrast of text + increasing spacing on Register page

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -6,7 +6,7 @@ export const Button: React.FC<
 > = ({ children, className, ...props }) => (
   <button
     className={classnames(
-      "block bg-primary-dark py-2 px-4 focus:outline-none focus-visible:outline-none focus-visible:ring focus-visible:ring-primary active:opacity-75 disabled:opacity-25",
+      "block text-trueWhite bg-primary-dark py-2 px-4 focus:outline-none focus-visible:outline-none focus-visible:ring focus-visible:ring-primary active:opacity-75 disabled:opacity-25",
       className
     )}
     {...props}

--- a/src/components/PageUserInfo.tsx
+++ b/src/components/PageUserInfo.tsx
@@ -18,7 +18,7 @@ export function isUserLoggedIn(): boolean {
 }
 
 export const PageUserInfo: React.FC = () => (
-  <div className="text-center">
+  <div className="text-center mb-14">
     { isUserLoggedIn() ? (
         storedUserData = localStorage.getItem("userData"),
         userInfo = JSON.parse(storedUserData || '{}'),
@@ -51,7 +51,7 @@ const LoggedInUserInfoPanel: React.FC<UserInfo> = ({avatar, username}) => {
           <h1 className="text-white font-bold text-lg text-left mx-6">
             {username}
           </h1>
-          <NavLink to="/logout" className="text-white text-right ml-6 hover:underline hover:cursor-pointer">Log Out</NavLink>
+          <NavLink to="/logout" className="bg-red-500 leading-none p-1.5 pb-2 rounded text-white text-right ml-6 hover:cursor-pointer">Log Out</NavLink>
         </div>
         <h1 className="text-white text-center mx-6">Team Skills Needed:</h1>
         <h1 className="text-white text-center mx-6">{teamSkills}</h1>

--- a/src/components/PageUserInfo.tsx
+++ b/src/components/PageUserInfo.tsx
@@ -51,7 +51,7 @@ const LoggedInUserInfoPanel: React.FC<UserInfo> = ({avatar, username}) => {
           <h1 className="text-white font-bold text-lg text-left mx-6">
             {username}
           </h1>
-          <NavLink to="/logout" className="bg-red-500 leading-none p-1.5 pb-2 rounded text-white text-right ml-6 hover:cursor-pointer">Log Out</NavLink>
+          <NavLink to="/logout" className="bg-red-500 text-trueWhite leading-none p-1.5 pb-2 rounded text-white text-right ml-6 hover:cursor-pointer">Log Out</NavLink>
         </div>
         <h1 className="text-white text-center mx-6">Team Skills Needed:</h1>
         <h1 className="text-white text-center mx-6">{teamSkills}</h1>

--- a/src/components/Team.tsx
+++ b/src/components/Team.tsx
@@ -86,7 +86,7 @@ export const Team: React.FC<{team:TeamData}> = ({team}) => {
       <a
         target="_blank" rel="noreferrer"
         href={`https://discordapp.com/users/${team.authorId}`}
-        className="text-sm p-2 leading-none absolute bottom-5 right-5 rounded"
+        className="text-sm p-2 leading-none absolute bottom-5 right-5 rounded text-trueWhite"
         style={{background:"#5865F2"}}
       >
         Message {author} on Discord

--- a/src/pages/About/About.tsx
+++ b/src/pages/About/About.tsx
@@ -4,7 +4,7 @@ import { ReactSVG } from "react-svg";
 const AboutPara: React.FC = ({children}) => (<p className="mb-2">{children}</p>);
 
 const FAQItem = (heading:string, children: React.ReactNode): React.ReactNode => (<>
-  <h2 className="text-3xl text-white font-light my-6">{heading}</h2>
+  <h2 className="text-3xl text-white font-light mb-4 mt-10">{heading}</h2>
   {children}
 </>);
 

--- a/src/pages/About/About.tsx
+++ b/src/pages/About/About.tsx
@@ -4,7 +4,7 @@ import { ReactSVG } from "react-svg";
 const AboutPara: React.FC = ({children}) => (<p className="mb-2">{children}</p>);
 
 const FAQItem = (heading:string, children: React.ReactNode): React.ReactNode => (<>
-  <h2 className="text-3xl text-white font-light mb-4 mt-10">{heading}</h2>
+  <h2 className="text-3xl text-white font-light mb-4 mt-12">{heading}</h2>
   {children}
 </>);
 

--- a/src/pages/Register/Register.tsx
+++ b/src/pages/Register/Register.tsx
@@ -102,6 +102,7 @@ export const Register: React.FC = () => {
           };
     
     // Hack, due to the fact that the API returns wrong data
+    // eslint-disable-next-line
     // @ts-ignore
     if(typeof newDefaultValues.languages === "string") newDefaultValues.languages = newDefaultValues.languages.split(",");
     reset(newDefaultValues);

--- a/src/pages/Register/Register.tsx
+++ b/src/pages/Register/Register.tsx
@@ -160,7 +160,7 @@ export const Register: React.FC = () => {
     <>
       <PageUserInfo />
       <form
-        className="mx-auto space-y-12 pb-12"
+        className="mx-auto space-y-14 pb-14"
         onSubmit={handleSubmit((data) =>
           saveMutate({ userTeam, formData: data })
         )}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,7 @@ const defaultTheme = require("tailwindcss/defaultTheme");
 const colors = require('tailwindcss/colors')
 
 const primaryBright = "#00FFC0";
-const primaryDark = "#16D0A2";
+const primaryDark = "#14bd93";
 
 module.exports = {
   mode: "jit",
@@ -21,6 +21,8 @@ module.exports = {
       },
       colors: {
         gray: colors.trueGray,
+        trueWhite: "#fff",
+        white: "#f0f0f0",
         primary: {
           DEFAULT: primaryBright,
           bright: primaryBright,


### PR DESCRIPTION
Reduced the contrast of text on the black background. Mainly, this was done by going into the tailwind config and setting `theme.colors.white` to "#f0f0f0". I also added `theme.colors.trueWhite`, for the few cases that truly require it - namely, buttons with coloured backgrounds - the new fake white doesn't contrast enough, making text hard to read.

The PrimaryDark colour has also been made even darker, to make the Update Team button much more readable (I think that's the only place it's used?)

Finally, there's also a lot more space between form items on the Register page, just to reduce visual noise, and try and make everything more clearly separate.

ETA: oh yeah, I also thought the heading spacing on the About page needed some tweaking, so I tweaked it.