### PR TITLE
Allows newlines in the list by replacing them with <br/>

### DIFF
--- a/src/components/Team.tsx
+++ b/src/components/Team.tsx
@@ -49,17 +49,12 @@ export const Team: React.FC<{team:TeamData}> = ({team}) => {
 
   const description: React.ReactNode[] = [];
   let numNewlines = 0;
-  
-  for(let i = 0; i < team.description.length; i++){
-    const c = team.description[i];
-    if(numNewlines < 12 && c == "\n") {
+
+  for(const x of team.description.split("\n") ){
+    description.push(x);
+    if(numNewlines < 12){
       description.push( (<br/>) );
       numNewlines++;
-    }
-    else {
-      const lastIndex = description.length - 1;
-      if(typeof description[lastIndex] == "string") description[lastIndex] += c;
-      else description.push(c);
     }
   }
 

--- a/src/components/Team.tsx
+++ b/src/components/Team.tsx
@@ -47,16 +47,14 @@ export const Team: React.FC<{team:TeamData}> = ({team}) => {
   const author = team.author.replace(/#\d{4}$/, "");
 
 
-  let description = "";
   let numNewlines = 0;
-
-  for(const x of team.description.split(/\r?\n/) ){
-    description += x;
-    if(numNewlines < 12){
-      description += "\n";
+  const description = team.description.replace(/\r?\n/g, (m) => {
+    if(numNewlines > 10) return ""
+    else {
       numNewlines++;
+      return m;
     }
-  }
+  })
 
   return (
     <div data-team-id={team.id} className="mb-24 p-6 border relative">

--- a/src/components/Team.tsx
+++ b/src/components/Team.tsx
@@ -47,13 +47,13 @@ export const Team: React.FC<{team:TeamData}> = ({team}) => {
   const author = team.author.replace(/#\d{4}$/, "");
 
 
-  const description: React.ReactNode[] = [];
+  let description = "";
   let numNewlines = 0;
 
-  for(const x of team.description.split("\n") ){
-    description.push(x);
+  for(const x of team.description.split(/\r?\n/) ){
+    description += x;
     if(numNewlines < 12){
-      description.push( (<br/>) );
+      description += "\n";
       numNewlines++;
     }
   }
@@ -72,7 +72,7 @@ export const Team: React.FC<{team:TeamData}> = ({team}) => {
 
       {/* flexbox for displaying description + skills */}
       <div className="flex">
-        <div className="flex-grow mr-5 overflow-hidden">
+        <div className="flex-grow mr-5 overflow-hidden whitespace-pre-wrap">
           {description}
         </div>
 

--- a/src/components/Team.tsx
+++ b/src/components/Team.tsx
@@ -43,7 +43,25 @@ export const Team: React.FC<{team:TeamData}> = ({team}) => {
       className="w-6 fill-primary inline-block m-1 align-top"
     />
   ));
+
   const author = team.author.replace(/#\d{4}$/, "");
+
+
+  const description: React.ReactNode[] = [];
+  let numNewlines = 0;
+  
+  for(let i = 0; i < team.description.length; i++){
+    const c = team.description[i];
+    if(numNewlines < 12 && c == "\n") {
+      description.push( (<br/>) );
+      numNewlines++;
+    }
+    else {
+      const lastIndex = description.length - 1;
+      if(typeof description[lastIndex] == "string") description[lastIndex] += c;
+      else description.push(c);
+    }
+  }
 
   return (
     <div data-team-id={team.id} className="mb-24 p-6 border relative">
@@ -60,7 +78,7 @@ export const Team: React.FC<{team:TeamData}> = ({team}) => {
       {/* flexbox for displaying description + skills */}
       <div className="flex">
         <div className="flex-grow mr-5 overflow-hidden">
-          {team.description}
+          {description}
         </div>
 
         <div className="flex-shrink-0 w-36">


### PR DESCRIPTION
This PR allows newlines in a Team post by replacing `\n` characters with `<br/>` elements. There's a hard cap of 12 newlines per post to prevent trolling, with the ability to report anybody who's trying to troll clearly in view.

Lots of users have already written posts thinking they'll be rendered with newlines, not realising that the post won't, and these posts look super messy without newlines.

Here's the worst that someone could do:
![image](https://user-images.githubusercontent.com/28653592/120401052-0a65e680-c337-11eb-868a-c7a275ac3dae.png)
