### PR TITLE
My stab at newline limits

### DIFF
--- a/src/components/Team.tsx
+++ b/src/components/Team.tsx
@@ -6,6 +6,7 @@ import { getSkillsets, Skillset } from "../utils/Skillsets";
 import { getDisplay } from "../utils/LanguageData";
 import { SkillsetSVG } from "./SkillsetSVG";
 import { ReportButton } from "./ReportButton";
+import { NUM_NEWLINES } from "../utils/consts";
 
 export class TeamData {
   author: string;
@@ -44,6 +45,15 @@ export const Team: React.FC<{team:TeamData}> = ({team}) => {
     />
   ));
   const author = team.author.replace(/#\d{4}$/, "");
+  
+  let numNewlines = 0;
+  const description = team.description.replace(/\r?\n/g, (m) => {
+    if(numNewlines > NUM_NEWLINES) return ""
+    else {
+      numNewlines++;
+      return m;
+    }
+  })
 
   return (
     <div data-team-id={team.id} className="mb-24 p-6 border relative">
@@ -60,7 +70,7 @@ export const Team: React.FC<{team:TeamData}> = ({team}) => {
       {/* flexbox for displaying description + skills */}
       <div className="flex">
         <div className="flex-grow mr-5 overflow-hidden whitespace-pre-wrap">
-          {team.description}
+          {description}
         </div>
 
         <div className="flex-shrink-0 w-36">

--- a/src/components/Team.tsx
+++ b/src/components/Team.tsx
@@ -69,7 +69,7 @@ export const Team: React.FC<{team:TeamData}> = ({team}) => {
 
       {/* flexbox for displaying description + skills */}
       <div className="flex">
-        <div className="flex-grow mr-5 overflow-hidden whitespace-pre-wrap">
+        <div className="flex-grow mr-5 overflow-hidden">
           {description}
         </div>
 

--- a/src/components/Team.tsx
+++ b/src/components/Team.tsx
@@ -4,9 +4,9 @@ import { enGB } from 'date-fns/locale';
 
 import { getSkillsets, Skillset } from "../utils/Skillsets";
 import { getDisplay } from "../utils/LanguageData";
+import { limitNewlines } from "../utils/limitNewlines";
 import { SkillsetSVG } from "./SkillsetSVG";
 import { ReportButton } from "./ReportButton";
-import { NUM_NEWLINES } from "../utils/consts";
 
 export class TeamData {
   author: string;
@@ -46,14 +46,7 @@ export const Team: React.FC<{team:TeamData}> = ({team}) => {
   ));
   const author = team.author.replace(/#\d{4}$/, "");
   
-  let numNewlines = 0;
-  const description = team.description.replace(/\r?\n/g, (m) => {
-    if(numNewlines > NUM_NEWLINES) return ""
-    else {
-      numNewlines++;
-      return m;
-    }
-  })
+  const description = limitNewlines(team.description);
 
   return (
     <div data-team-id={team.id} className="mb-24 p-6 border relative">

--- a/src/components/Team.tsx
+++ b/src/components/Team.tsx
@@ -69,7 +69,7 @@ export const Team: React.FC<{team:TeamData}> = ({team}) => {
 
       {/* flexbox for displaying description + skills */}
       <div className="flex">
-        <div className="flex-grow mr-5 overflow-hidden">
+        <div className="flex-grow mr-5 overflow-hidden whitespace-pre-wrap">
           {description}
         </div>
 

--- a/src/components/Team.tsx
+++ b/src/components/Team.tsx
@@ -59,7 +59,7 @@ export const Team: React.FC<{team:TeamData}> = ({team}) => {
 
       {/* flexbox for displaying description + skills */}
       <div className="flex">
-        <div className="flex-grow mr-5 overflow-hidden">
+        <div className="flex-grow mr-5 overflow-hidden whitespace-pre-wrap">
           {team.description}
         </div>
 

--- a/src/components/Team.tsx
+++ b/src/components/Team.tsx
@@ -44,9 +44,8 @@ export const Team: React.FC<{team:TeamData}> = ({team}) => {
       className="w-6 fill-primary inline-block m-1 align-top"
     />
   ));
-  const author = team.author.replace(/#\d{4}$/, "");
   
-  const description = limitNewlines(team.description);
+  const author = team.author.replace(/#\d{4}$/, "");
 
   return (
     <div data-team-id={team.id} className="mb-24 p-6 border relative">
@@ -63,7 +62,7 @@ export const Team: React.FC<{team:TeamData}> = ({team}) => {
       {/* flexbox for displaying description + skills */}
       <div className="flex">
         <div className="flex-grow mr-5 overflow-hidden whitespace-pre-wrap">
-          {description}
+          {limitNewlines(team.description)}
         </div>
 
         <div className="flex-shrink-0 w-36">

--- a/src/pages/Register/Register.tsx
+++ b/src/pages/Register/Register.tsx
@@ -18,6 +18,7 @@ import { languages } from "../../utils/LanguageData";
 import { AddMessage } from "../../components/StatusMessenger";
 import { MultiSelect } from "../../components/MultiSelect";
 import { ArrayToRecord } from "../../utils/ArrayToRecord";
+import { limitNewlines } from "../../utils/limitNewlines";
 
 const languageSelectIndex: Record<string, string> = ArrayToRecord(languages, l => [l.code, l.display]);
 
@@ -206,19 +207,30 @@ export const Register: React.FC = () => {
             Characters Remaining:{" "}
             <span className={remainColor}>{charRemain}</span>
           </label>
-          <textarea
-            style={{ resize: "none" }}
-            className={classnames(
-              "rounded text-md bg-transparent border px-4 py-2 block w-full placeholder-white placeholder-opacity-40 h-36 disabled:opacity-50",
-              formState.errors.description
-                ? "border-red-400 focus:border-red-500"
-                : "border-white focus:border-primary"
-            )}
-            disabled={isLoading}
-            placeholder="This is my first jam, though I've made some small games before&#10;I like to do level design for platformers (like Celeste), and sometimes I code for Unity&#10;Ideally I want a team of 3 people - mostly I need an artist"
-            id="description"
-            {...register("description", { required: "Required" })}
+          <Controller
+            name="description"
+            rules={{ required: "Required" }}
+            control={control} 
+            render={({ field }) =>
+              <textarea
+                style={{ resize: "none" }}
+                className={classnames(
+                  "rounded text-md bg-transparent border px-4 py-2 block w-full placeholder-white placeholder-opacity-40 h-36 disabled:opacity-50",
+                  formState.errors.description
+                    ? "border-red-400 focus:border-red-500"
+                    : "border-white focus:border-primary"
+                )}
+                disabled={isLoading}
+                placeholder="This is my first jam, though I've made some small games before&#10;I like to do level design for platformers (like Celeste), and sometimes I code for Unity&#10;Ideally I want a team of 3 people - mostly I need an artist"
+                id="description"
+                {...field}
+                onChange={e => {
+                  field.onChange(limitNewlines(e.target.value));
+                }}
+              />
+            }
           />
+         
           {formState.errors.description && (
             <div className="text-red-400">
               {formState.errors.description.message}

--- a/src/utils/consts.ts
+++ b/src/utils/consts.ts
@@ -1,0 +1,1 @@
+export const NUM_NEWLINES = 10;

--- a/src/utils/limitNewlines.ts
+++ b/src/utils/limitNewlines.ts
@@ -2,13 +2,12 @@ import { NUM_NEWLINES } from "./consts";
 
 const newlineRegex = /\r?\n/g;
 export const limitNewlines = (input: string): string => {
-  const newlines = [...input.matchAll(/\r?\n/g)];
-  if (newlines.length > NUM_NEWLINES) {
-    const firstNewlineToBeRemoved = newlines[NUM_NEWLINES];
-    return (
-      input.slice(0, firstNewlineToBeRemoved.index) +
-      input.slice(firstNewlineToBeRemoved.index).replace(newlineRegex, "")
-    );
-  }
-  return input;
+  let numNewlines = 0;
+  return input.replace(newlineRegex, (m) => {
+    if (numNewlines > NUM_NEWLINES) return "";
+    else {
+      numNewlines++;
+      return m;
+    }
+  });
 };

--- a/src/utils/limitNewlines.ts
+++ b/src/utils/limitNewlines.ts
@@ -1,9 +1,10 @@
 import { NUM_NEWLINES } from "./consts";
 
 const newlineRegex = /\r?\n/g;
+
 export const limitNewlines = (input: string): string => {
   let numNewlines = 0;
-  return input.replace(newlineRegex, (m) => {
+  return input.replace(newlineRegex, m => {
     if (numNewlines > NUM_NEWLINES) return "";
     else {
       numNewlines++;

--- a/src/utils/limitNewlines.ts
+++ b/src/utils/limitNewlines.ts
@@ -1,0 +1,12 @@
+const newlineRegex = /\r?\n/g;
+export const limitNewlines = (input: string): string => {
+  const newlines = [...input.matchAll(/\r?\n/g)];
+  if (newlines.length > 10) {
+    const firstNewlineToBeRemoved = newlines[10];
+    return (
+      input.slice(0, firstNewlineToBeRemoved.index) +
+      input.slice(firstNewlineToBeRemoved.index).replace(newlineRegex, "")
+    );
+  }
+  return input;
+};

--- a/src/utils/limitNewlines.ts
+++ b/src/utils/limitNewlines.ts
@@ -5,7 +5,7 @@ const newlineRegex = /\r?\n/g;
 export const limitNewlines = (input: string): string => {
   let numNewlines = 0;
   return input.replace(newlineRegex, m => {
-    if (numNewlines > NUM_NEWLINES) return "";
+    if (numNewlines >= NUM_NEWLINES) return "";
     else {
       numNewlines++;
       return m;

--- a/src/utils/limitNewlines.ts
+++ b/src/utils/limitNewlines.ts
@@ -1,8 +1,10 @@
+import { NUM_NEWLINES } from "./consts";
+
 const newlineRegex = /\r?\n/g;
 export const limitNewlines = (input: string): string => {
   const newlines = [...input.matchAll(/\r?\n/g)];
-  if (newlines.length > 10) {
-    const firstNewlineToBeRemoved = newlines[10];
+  if (newlines.length > NUM_NEWLINES) {
+    const firstNewlineToBeRemoved = newlines[NUM_NEWLINES];
     return (
       input.slice(0, firstNewlineToBeRemoved.index) +
       input.slice(firstNewlineToBeRemoved.index).replace(newlineRegex, "")


### PR DESCRIPTION
Limit the newlines when creating a team, to help better show where the limit is.

Also add a little CSS flag to the Team description so we don't need to add `br`s and the content just renders with all the whitespace from the DB.